### PR TITLE
added a way to filter devices by state for CoreAudioController

### DIFF
--- a/AudioSwitcher.AudioApi.CoreAudio/AudioSwitcher.AudioApi.CoreAudio.projitems
+++ b/AudioSwitcher.AudioApi.CoreAudio/AudioSwitcher.AudioApi.CoreAudio.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CoreAudioDevice.SessionController.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CoreAudioSession.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CoreAudioSessionController.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)EDeviceState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\AudioEndpointVolume.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\AudioEndpointVolumeCallback.cs" />
@@ -31,7 +32,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Internal\EAudioSessionDisconnectReason.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\EAudioSessionState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\EDataFlow.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Internal\EDeviceState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\EndpointHardwareSupport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\ERole.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\Interfaces\AudioVolumeNotificationDataStruct.cs" />

--- a/AudioSwitcher.AudioApi.CoreAudio/CoreAudioController.cs
+++ b/AudioSwitcher.AudioApi.CoreAudio/CoreAudioController.cs
@@ -23,7 +23,7 @@ namespace AudioSwitcher.AudioApi.CoreAudio
 
         private IMultimediaDeviceEnumerator InnerEnumerator => _innerEnumerator.Value;
 
-        public CoreAudioController()
+        public CoreAudioController(EDeviceState stateMask = EDeviceState.All)
         {
             // ReSharper disable once SuspiciousTypeConversion.Global
             var innerEnumerator = ComObjectFactory.GetDeviceEnumerator();
@@ -43,7 +43,7 @@ namespace AudioSwitcher.AudioApi.CoreAudio
 
                 _deviceCache = new HashSet<CoreAudioDevice>();
                 IMultimediaDeviceCollection collection;
-                InnerEnumerator.EnumAudioEndpoints(EDataFlow.All, EDeviceState.All, out collection);
+                InnerEnumerator.EnumAudioEndpoints(EDataFlow.All, stateMask, out collection);
 
                 using (var coll = new MultimediaDeviceCollection(collection))
                 {

--- a/AudioSwitcher.AudioApi.CoreAudio/EDeviceState.cs
+++ b/AudioSwitcher.AudioApi.CoreAudio/EDeviceState.cs
@@ -3,7 +3,7 @@
 namespace AudioSwitcher.AudioApi.CoreAudio
 {
     [Flags]
-    internal enum EDeviceState : uint
+    public enum EDeviceState : uint
     {
         Active = 0x00000001,
         Disabled = 0x00000002,


### PR DESCRIPTION
### Changed:
 - EDeviceState.cs was moved up from the `Internal` folder and it now has the protection level `public` instead of `internal`.
 - `CoreAudioController` constructor now takes an optional `EDeviceState stateMask` (EDeviceState.All by default) to filter the devices it caches in memory by state.

This was added to reduce the amount of time it takes for the constructor to return. On some computers, it was taking 50 seconds. Here is an example where it took 30+ seconds. [EDeviceState.All.txt](https://github.com/xenolightning/AudioSwitcher/files/3044270/EDeviceState.All.txt)
Here is what happened when I added the filter `EDeviceState.Active`, it took less than a second. [EDeviceState.Active.txt](https://github.com/xenolightning/AudioSwitcher/files/3044287/EDeviceState.Active.txt)
