### PR TITLE
Fix: "IsDefaultDevice" property may be incorrect.

### DIFF
--- a/AudioSwitcher.AudioApi.CoreAudio/CoreAudioDevice.cs
+++ b/AudioSwitcher.AudioApi.CoreAudio/CoreAudioDevice.cs
@@ -465,13 +465,13 @@ namespace AudioSwitcher.AudioApi.CoreAudio
             Marshal.ThrowExceptionForHR(Device.GetState(out _state));
             Marshal.ThrowExceptionForHR(Device.GetId(out _globalId));
 
-            //load the initial default state. Have to query using device id because this device is not cached until after creation
-            _isDefaultCommDevice = _controller.GetDefaultDeviceId(DeviceType, Role.Communications) == RealId;
-            _isDefaultDevice = _controller.GetDefaultDeviceId(DeviceType, Role.Multimedia | Role.Console) == RealId;
-
             // ReSharper disable once SuspiciousTypeConversion.Global
             var ep = Device as IMultimediaEndpoint;
             ep?.GetDataFlow(out _dataFlow);
+
+            //load the initial default state. Have to query using device id because this device is not cached until after creation
+            _isDefaultCommDevice = _controller.GetDefaultDeviceId(DeviceType, Role.Communications) == RealId;
+            _isDefaultDevice = _controller.GetDefaultDeviceId(DeviceType, Role.Multimedia | Role.Console) == RealId;
 
             GetPropertyInformation(Device);
         }


### PR DESCRIPTION
Sometimes, the "IsDefaultDevice" property returns incorrect value.

In my case, the "IsDefaultDevice" property of all capture devices on my PC are always `false`.

This is because when determining whether a device is the default device, it depends on the `DeviceType` property, but it was determined before the `DeviceType` property was determined.

Therefore, I exchanged the code steps to determining whether a device is the default device after `DeviceType` property was determined.

P.S.
Thank you for your great works! 👍 