### PR TITLE
null check

### DIFF
--- a/AudioSwitcher.AudioApi.CoreAudio/CoreAudioSessionController.cs
+++ b/AudioSwitcher.AudioApi.CoreAudio/CoreAudioSessionController.cs
@@ -171,6 +171,10 @@ namespace AudioSwitcher.AudioApi.CoreAudio
         {
             IAudioSessionEnumerator enumerator;
             _audioSessionManager.GetSessionEnumerator(out enumerator);
+
+            if (enumerator == null)
+                return;
+
             int count;
             enumerator.GetCount(out count);
 


### PR DESCRIPTION
OK, this is a patch for 3.0 branch to add a simple null check. 

There don't seem to be any 3.0 branch to merge this to, so I'd recommend perhaps creating a new one.

If this patch is published, it would make AudioSwitcher.AudioApi.CoreAudio 3.0.0.2.

I was excepting this merge to give some sort of error or warning because it's meant to apply to an old version (08023f8)