### PR TITLE
avoid unnecessarily triggering STA COM thread check

### DIFF
--- a/AudioSwitcher.AudioApi.CoreAudio/CoreAudioSession.cs
+++ b/AudioSwitcher.AudioApi.CoreAudio/CoreAudioSession.cs
@@ -125,7 +125,7 @@ namespace AudioSwitcher.AudioApi.CoreAudio
             get
             {
                 //only initialize the timer subscription when peak value is requested
-                if (MeterInformation != null && _timerSubscription == null)
+                if (_meterInformation != null && _timerSubscription == null)
                 {
                     //start a timer to poll for peak value changes
                     _timerSubscription = PeakValueTimer.PeakValueTick.Subscribe(Timer_UpdatePeakValue);


### PR DESCRIPTION
This is another tiny patch. it's also a little lazy: I haven't got the library to compile yet so haven't checked if it 100% fixes the problem.

This time it's for the most recent release. (I went and updated my code to 4.0-alpha)

For background, here's my client code which I'm having trouble with:

```
AudioSession.StateChanged.Subscribe(this); // OK
AudioSession.MuteChanged.Subscribe(this); // OK
AudioSession.VolumeChanged.Subscribe(this); // OK
AudioSession.Disconnected.Subscribe(this); // OK
AudioSession.PeakValueChanged.Subscribe(this); // ❌ InvalidThreadException: This operation must be run on a STA COM Thread
```
It's not the `.Subscribe(this)` that fails, but the `CoreAudioSession.PeakValueChanged` getter.

During PeakValueChanged's getter routine, there's a null check for a variable (MeterInformation), and during MeterInformation's getter there's a `ComThread.Assert();` which fails.

This patch simply bypasses the getter (`MeterInformation` -> `_meterInformation`). I'm assuming a STA thread isn't needed here.

I was going to try compiling it first, but I couldn't get that set up immediately, and might not get a chance to do that for a few days so thought I'd post a PR now while it's still fresh in my head.

**Edit:** Had another go and got it compiling and got it going, and the problem it's meant to fix has indeed gone away with this patch.