### PR TITLE
Public CoreAudioDevice.Properties

### DIFF
--- a/AudioSwitcher.AudioApi.CoreAudio/CoreAudioDevice.Internal.cs
+++ b/AudioSwitcher.AudioApi.CoreAudio/CoreAudioDevice.Internal.cs
@@ -51,15 +51,6 @@ namespace AudioSwitcher.AudioApi.CoreAudio
         private ThreadLocal<IAudioMeterInformation> _audioMeterInformation;
         private IntPtr _audioMeterInformationPtr;
 
-        private IPropertyDictionary Properties
-        {
-            get
-            {
-                ThrowIfDisposed();
-                return _properties;
-            }
-        }
-
         /// <summary>
         /// Audio Meter Information - Future support
         /// </summary>

--- a/AudioSwitcher.AudioApi.CoreAudio/CoreAudioDevice.cs
+++ b/AudioSwitcher.AudioApi.CoreAudio/CoreAudioDevice.cs
@@ -58,6 +58,15 @@ namespace AudioSwitcher.AudioApi.CoreAudio
             }
         }
 
+        public IPropertyDictionary Properties
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _properties;
+            }
+        }
+
         /// <summary>
         ///     Unique identifier for this device
         /// </summary>

--- a/AudioSwitcher.AudioApi.CoreAudio/Internal/CachedPropertyDictionary.cs
+++ b/AudioSwitcher.AudioApi.CoreAudio/Internal/CachedPropertyDictionary.cs
@@ -127,5 +127,15 @@ namespace AudioSwitcher.AudioApi.CoreAudio
             Marshal.ThrowExceptionForHR(_propertyStoreInteface.SetValue(ref key, ref value));
             _propertyStoreInteface.Commit();
         }
+
+        public IEnumerator<KeyValuePair<PropertyKey, object>> GetEnumerator()
+        {
+            return _properties.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 }

--- a/AudioSwitcher.AudioApi.CoreAudio/Internal/IPropertyDictionary.cs
+++ b/AudioSwitcher.AudioApi.CoreAudio/Internal/IPropertyDictionary.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace AudioSwitcher.AudioApi.CoreAudio
 {
-    internal interface IPropertyDictionary : IDisposable
+    public interface IPropertyDictionary : IDisposable
     {
         AccessMode Mode { get; }
 
@@ -14,7 +14,7 @@ namespace AudioSwitcher.AudioApi.CoreAudio
     }
 
     [Flags]
-    internal enum AccessMode
+    public enum AccessMode
     {
         Read,
         Write,

--- a/AudioSwitcher.AudioApi.CoreAudio/Internal/IPropertyDictionary.cs
+++ b/AudioSwitcher.AudioApi.CoreAudio/Internal/IPropertyDictionary.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Collections.Generic;
 
 namespace AudioSwitcher.AudioApi.CoreAudio
 {
-    public interface IPropertyDictionary : IDisposable
+    public interface IPropertyDictionary : IDisposable, IEnumerable<KeyValuePair<PropertyKey, object>>
     {
         AccessMode Mode { get; }
 


### PR DESCRIPTION
I just migrated my wip project from NAudio.CoreAudioApi to AudioSwitcher.AudioApi. The only missing feature I needed was access to the full device properties. The code was mostly there already, so I made it public.